### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -42,7 +42,7 @@ class ItemsController < ApplicationController
 
   def destroy
     @item.destroy
-    redirect_to root_path, notice: "商品を削除しました"
+    redirect_to root_path, notice: '商品を削除しました'
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
-  before_action :move_to_root, only: [:edit, :update]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :move_to_root, only: [:edit, :update, :destroy]
 
   def index
     @items = Item.order(created_at: :desc)
@@ -38,6 +38,11 @@ class ItemsController < ApplicationController
     else
       render :edit, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path, notice: "商品を削除しました"
   end
 
   private

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,6 +27,8 @@
       <% if user_signed_in? %>
         <% if current_user.id == @item.user_id %>
           <%= link_to "商品の編集", edit_item_path(@item), class: "item-red-btn" %>
+          <p class="or-text">or</p>
+          <%= link_to "削除", item_path(@item), data: { turbo_method: :delete }, class:"item-destroy" %>
         <% else %>
           <%= link_to "購入画面に進む", "#", class:"item-red-btn" %>
         <% end %>
@@ -102,115 +104,6 @@
     <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   </div>
 <% end %>
-
-<%= render "shared/footer" %>
-=======
-<%# 商品の概要 %>
-<div class="item-show">
-  <div class="item-box">
-    <h2 class="name">
-      <%= @item.name %>
-    </h2>
-
-    <div class="item-img-content">
-      <%= image_tag @item.image, class: "item-box-img" %>
-      <%# 購入機能未実装のため sold out 表示はコメントアウト %>
-      <%# if @item.purchase.present? %>
-      <%#   <div class="sold-out"> %>
-      <%#     <span>Sold Out!!</span> %>
-      <%#   </div> %>
-      <%# end %>
-    </div>
-
-    <div class="item-price-box">
-      <span class="item-price">
-        ¥ <%= number_with_delimiter(@item.price) %>
-      </span>
-      <span class="item-postage">
-        <%= @item.shipping_fee.name %>
-      </span>
-    </div>
-
-    <%# ボタン表示制御（現段階で実装必須部分） %>
-    <% if user_signed_in? %>
-      <% if current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", "#", class: "item-red-btn" %>
-        <p class="or-text">or</p>
-        <%= link_to "削除", "#", data: { turbo_method: :delete }, class:"item-destroy" %>
-      <% else %>
-        <%= link_to "購入画面に進む", "#", class:"item-red-btn" %>
-      <% end %>
-    <% end %>
-
-    <div class="item-explain-box">
-      <span><%= @item.description %></span>
-    </div>
-
-    <table class="detail-table">
-      <tbody>
-        <tr>
-          <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user.nickname %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= @item.category.name %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= @item.condition.name %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= @item.shipping_fee.name %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= @item.prefecture.name %></td>
-        </tr>
-        <tr>
-          <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= @item.shipping_day.name %></td>
-        </tr>
-      </tbody>
-    </table>
-    <div class="option">
-      <div class="favorite-btn">
-        <%= image_tag "star.png" ,class:"favorite-star-icon" ,width:"20",height:"20"%>
-        <span>お気に入り 0</span>
-      </div>
-      <div class="report-btn">
-        <%= image_tag "flag.png" ,class:"report-flag-icon" ,width:"20",height:"20"%>
-        <span>不適切な商品の通報</span>
-      </div>
-    </div>
-  </div>
-  <%# /商品の概要 %>
-
-  <div class="comment-box">
-    <form>
-      <textarea class="comment-text"></textarea>
-      <p class="comment-warn">
-        相手のことを考え丁寧なコメントを心がけましょう。
-        <br>
-        不快な言葉遣いなどは利用制限や退会処分となることがあります。
-      </p>
-      <button type="submit" class="comment-btn">
-        <%= image_tag "comment.png" ,class:"comment-flag-icon" ,width:"20",height:"25"%>
-        <span>コメントする<span>
-      </button>
-    </form>
-  </div>
-  <div class="links">
-    <a href="#" class="change-item-btn">
-      ＜ 前の商品
-    </a>
-    <a href="#" class="change-item-btn">
-      後ろの商品 ＞
-    </a>
-  </div>
-  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-</div>
 
 <%= render "shared/footer" %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :items, only: [:index, :show, :new, :create, :edit, :update]
+  resources :items
   root "items#index"
 end


### PR DESCRIPTION
# What
商品詳細ページにおいて、ログイン中の出品者が自身の出品した商品を削除できる機能を実装しました。

削除後はトップページに遷移するようにしました。

「削除」ボタンは出品者本人にのみ表示されるようにビューで条件分岐を設定しました。

コントローラーでも削除できるユーザーを出品者本人に限定するよう条件を設け、セキュリティを確保しました。
# Why
不正アクセスによる他人の商品削除を防ぐため、ビューとコントローラーの両方で権限
をチェックする必要があるため。

削除操作後の遷移先をトップページにすることで、ユーザーが操作後に迷わずアプリを利用できるようにするため。


ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/496afa57ba81c2156c5d1c0a4dfed02b